### PR TITLE
Add some assertions for Try.Failure

### DIFF
--- a/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
@@ -213,7 +213,7 @@ abstract class AbstractTryAssert<SELF extends AbstractTryAssert<SELF, VALUE>, VA
      * @param exceptionMessage the expected exception message.
      * @return this assertion object.
      */
-    public <U extends Throwable> SELF failReasonHasMessage(String exceptionMessage){
+    public SELF failReasonHasMessage(String exceptionMessage){
         isNotNull();
         checkNotNull(exceptionMessage);
         assertIsFailure();

--- a/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
@@ -28,7 +28,9 @@ import java.util.Comparator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Preconditions.checkArgument;
+import static org.assertj.vavr.api.TryShouldBeFailure.shouldBeFailure;
 import static org.assertj.vavr.api.TryShouldBeSuccess.shouldBeSuccess;
 import static org.assertj.vavr.api.TryShouldContain.shouldContain;
 import static org.assertj.vavr.api.TryShouldContain.shouldContainSame;
@@ -191,6 +193,20 @@ abstract class AbstractTryAssert<SELF extends AbstractTryAssert<SELF, VALUE>, VA
         return VavrAssertions.assertThat(actual.map(mapper));
     }
 
+    /**
+     * Verifies that the actual @{@link io.vavr.control.Try} fails because of specific {@link Throwable}.
+
+     * @param reason the expected exception class.
+     * @return this assertion object.
+     */
+    public <U extends Throwable> SELF failBecauseOf(Class<U> reason){
+        isNotNull();
+        checkNotNull(reason);
+        assertIsFailure();
+        assertThat(actual.getCause()).isInstanceOf(reason);
+        return myself;
+    }
+
     private void checkNotNull(Object expectedValue) {
         checkArgument(expectedValue != null, "The expected value should not be <null>.");
     }
@@ -198,6 +214,11 @@ abstract class AbstractTryAssert<SELF extends AbstractTryAssert<SELF, VALUE>, VA
     private void assertIsSuccess() {
         isNotNull();
         if (actual.isEmpty()) throwAssertionError(shouldBeSuccess());
+    }
+
+    private void assertIsFailure() {
+        isNotNull();
+        if (actual.isSuccess()) throwAssertionError(shouldBeFailure());
     }
 }
 

--- a/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
@@ -195,7 +195,7 @@ abstract class AbstractTryAssert<SELF extends AbstractTryAssert<SELF, VALUE>, VA
 
     /**
      * Verifies that the actual @{@link io.vavr.control.Try} fails because of specific {@link Throwable}.
-
+     *
      * @param reason the expected exception class.
      * @return this assertion object.
      */
@@ -204,6 +204,20 @@ abstract class AbstractTryAssert<SELF extends AbstractTryAssert<SELF, VALUE>, VA
         checkNotNull(reason);
         assertIsFailure();
         assertThat(actual.getCause()).isInstanceOf(reason);
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual @{@link io.vavr.control.Try} fails with specific message.
+     *
+     * @param exceptionMessage the expected exception message.
+     * @return this assertion object.
+     */
+    public <U extends Throwable> SELF failReasonHasMessage(String exceptionMessage){
+        isNotNull();
+        checkNotNull(exceptionMessage);
+        assertIsFailure();
+        assertThat(actual.getCause()).hasMessage(exceptionMessage);
         return myself;
     }
 

--- a/src/main/java/org/assertj/vavr/api/TryShouldBeFailure.java
+++ b/src/main/java/org/assertj/vavr/api/TryShouldBeFailure.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.vavr.api;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Build error message when a value should not be present in an {@link io.vavr.control.Try}.
+ *
+ * @author Bartlomiej Kuczynski
+ */
+class TryShouldBeFailure extends BasicErrorMessageFactory {
+
+    private TryShouldBeFailure() {
+        super(format("%nExpecting Try to be a Failure, but wasn't"));
+    }
+
+    /**
+     * Indicates that a value should not be present in an non-empty {@link io.vavr.control.Try}.
+     *
+     * @return a error message factory.
+     * @throws NullPointerException if Try is null.
+     */
+    static TryShouldBeFailure shouldBeFailure() {
+        return new TryShouldBeFailure();
+    }
+}

--- a/src/test/java/org/assertj/vavr/api/TryAssert_failBecauseOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_failBecauseOf_Test.java
@@ -1,0 +1,34 @@
+package org.assertj.vavr.api;
+
+import io.vavr.control.Try;
+import org.assertj.vavr.test.BaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.vavr.api.VavrAssertions.assertThat;
+
+public class TryAssert_failBecauseOf_Test extends BaseTest {
+
+    @Test
+    public void should_fail_when_try_is_null() throws Exception {
+        thrown.expectAssertionError(actualIsNull());
+        assertThat((Try<String>) null).failBecauseOf(NullPointerException.class);
+    }
+
+    @Test
+    public void should_fail_when_reason_is_null() throws Exception {
+        thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+        assertThat(Try.failure(new NullPointerException())).failBecauseOf(null);
+    }
+
+    @Test
+    public void should_fail_when_try_is_success() throws Exception {
+        thrown.expectAssertionError("\nExpecting Try to be a Failure, but wasn't");
+        assertThat(Try.success("OK")).failBecauseOf(Throwable.class);
+    }
+
+    @Test
+    public void should_pass_when_try_fail_with_specific_reason() throws Exception {
+        assertThat(Try.failure(new NullPointerException())).failBecauseOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/org/assertj/vavr/api/TryAssert_failReasonHasMessage_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_failReasonHasMessage_Test.java
@@ -1,0 +1,34 @@
+package org.assertj.vavr.api;
+
+import io.vavr.control.Try;
+import org.assertj.vavr.test.BaseTest;
+import org.junit.Test;
+
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.vavr.api.VavrAssertions.assertThat;
+
+public class TryAssert_failReasonHasMessage_Test extends BaseTest {
+
+    @Test
+    public void should_fail_when_try_is_null() throws Exception {
+        thrown.expectAssertionError(actualIsNull());
+        assertThat((Try<String>) null).failReasonHasMessage("");
+    }
+
+    @Test
+    public void should_fail_when_reason_is_null() throws Exception {
+        thrown.expectIllegalArgumentException("The expected value should not be <null>.");
+        assertThat(Try.failure(new NullPointerException())).failReasonHasMessage(null);
+    }
+
+    @Test
+    public void should_fail_when_try_is_success() throws Exception {
+        thrown.expectAssertionError("\nExpecting Try to be a Failure, but wasn't");
+        assertThat(Try.success("OK")).failReasonHasMessage("Some reason");
+    }
+
+    @Test
+    public void should_pass_when_try_fail_with_specific_reason() throws Exception {
+        assertThat(Try.failure(new NullPointerException("ops"))).failReasonHasMessage("ops");
+    }
+}


### PR DESCRIPTION
Add two basic assertions.

First checks exception class of `Try.getCause()`
Second verifies message of this exception.