### PR TITLE
Add hasValueSatisfying Methods to Either Assertions

### DIFF
--- a/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
@@ -23,6 +23,7 @@ import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.util.CheckReturnValue;
 
 import java.util.Comparator;
+import java.util.function.Consumer;
 
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.vavr.api.EitherShouldBeLeft.shouldBeLeft;
@@ -150,6 +151,71 @@ abstract class AbstractEitherAssert<SELF extends AbstractEitherAssert<SELF, LEFT
         assertIsLeft();
         if (!clazz.isInstance(actual.getLeft()))
             throwAssertionError(shouldContainOnLeftInstanceOf(actual, clazz));
+        return myself;
+    }
+
+    /**
+     * Verifies that the actual {@link io.vavr.control.Either} contains a right-sided value and gives this value to the given
+     * {@link java.util.function.Consumer} for further assertions. Should be used as a way of deeper asserting on the
+     * containing object, as further requirement(s) for the value.
+     * <p>
+     * Assertions will pass :
+     * <pre><code class='java'> // one requirement
+     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; assertThat(it).isEqualTo("something"));
+     *
+     * // multiple requirements
+     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; {
+     *   assertThat(it).isEqualTo("something");
+     *   assertThat(it).startsWith("some");
+     *   assertThat(it).endsWith("thing");
+     * }); </code></pre>
+     *
+     * Assertions will fail :
+     * <pre><code class='java'>
+     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; assertThat(it).isEqualTo("something else"));
+     *
+     * // fail because Either is left-sided, there is no value to perform assertion on
+     * assertThat(Either.left(42)).hasValueSatisfying(it -&gt; {});</code></pre>
+     *
+     * @param requirement to further assert on the right-sided object contained inside the {@link io.vavr.control.Either}.
+     * @return this assertion object.
+     */
+    public SELF hasValueSatisfying(Consumer<RIGHT> requirement) {
+        assertIsRight();
+        requirement.accept(actual.get());
+        return myself;
+    }
+
+
+    /**
+     * Verifies that the actual {@link io.vavr.control.Either} contains a left-sided value and gives this value to the given
+     * {@link java.util.function.Consumer} for further assertions. Should be used as a way of deeper asserting on the
+     * containing object, as further requirement(s) for the value.
+     * <p>
+     * Assertions will pass :
+     * <pre><code class='java'> // one requirement
+     * assertThat(Either.left(42)).hasLeftValueSatisfying(it -&gt; assertThat(it).isEqualTo(42));
+     *
+     * // multiple requirements
+     * assertThat(Either.left(42)).hasLeftValueSatisfying(it -&gt; {
+     *   assertThat(it).isEqualTo(42);
+     *   assertThat(it).isLessThan(100);
+     *   assertThat(it).isGreaterThan(0);
+     * }); </code></pre>
+     *
+     * Assertions will fail :
+     * <pre><code class='java'>
+     * assertThat(Either.left(42)).hasLeftValueSatisfying(it -&gt; assertThat(it).isEqualTo(24));
+     *
+     * // fail because Either is right-sided, there is no value to perform assertion on
+     * assertThat(Either.right("something")).hasLeftValueSatisfying(it -&gt; {});</code></pre>
+     *
+     * @param requirement to further assert on the left-sided object contained inside the {@link io.vavr.control.Either}.
+     * @return this assertion object.
+     */
+    public SELF hasLeftValueSatisfying(Consumer<LEFT> requirement) {
+        assertIsLeft();
+        requirement.accept(actual.getLeft());
         return myself;
     }
 

--- a/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
@@ -161,10 +161,10 @@ abstract class AbstractEitherAssert<SELF extends AbstractEitherAssert<SELF, LEFT
      * <p>
      * Assertions will pass :
      * <pre><code class='java'> // one requirement
-     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; assertThat(it).isEqualTo("something"));
+     * assertThat(Either.right("something")).hasRightValueSatisfying(it -&gt; assertThat(it).isEqualTo("something"));
      *
      * // multiple requirements
-     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; {
+     * assertThat(Either.right("something")).hasRightValueSatisfying(it -&gt; {
      *   assertThat(it).isEqualTo("something");
      *   assertThat(it).startsWith("some");
      *   assertThat(it).endsWith("thing");
@@ -172,20 +172,20 @@ abstract class AbstractEitherAssert<SELF extends AbstractEitherAssert<SELF, LEFT
      *
      * Assertions will fail :
      * <pre><code class='java'>
-     * assertThat(Either.right("something")).hasValueSatisfying(it -&gt; assertThat(it).isEqualTo("something else"));
+     * assertThat(Either.right("something")).hasRightValueSatisfying(it -&gt; assertThat(it).isEqualTo("something else"));
      *
      * // fail because Either is left-sided, there is no value to perform assertion on
-     * assertThat(Either.left(42)).hasValueSatisfying(it -&gt; {});</code></pre>
+     * assertThat(Either.left(42)).hasRightValueSatisfying(it -&gt; {});</code></pre>
      *
      * @param requirement to further assert on the right-sided object contained inside the {@link io.vavr.control.Either}.
      * @return this assertion object.
      */
-    public SELF hasValueSatisfying(Consumer<RIGHT> requirement) {
+    public SELF hasRightValueSatisfying(Consumer<RIGHT> requirement) {
         assertIsRight();
         requirement.accept(actual.get());
         return myself;
     }
-    
+
     /**
      * Verifies that the actual {@link io.vavr.control.Either} contains a left-sided value and gives this value to the given
      * {@link java.util.function.Consumer} for further assertions. Should be used as a way of deeper asserting on the

--- a/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
@@ -185,8 +185,7 @@ abstract class AbstractEitherAssert<SELF extends AbstractEitherAssert<SELF, LEFT
         requirement.accept(actual.get());
         return myself;
     }
-
-
+    
     /**
      * Verifies that the actual {@link io.vavr.control.Either} contains a left-sided value and gives this value to the given
      * {@link java.util.function.Consumer} for further assertions. Should be used as a way of deeper asserting on the

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
@@ -13,10 +13,10 @@
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.vavr.api.EitherShouldBeLeft.shouldBeLeft;
@@ -51,7 +51,7 @@ class EitherAssert_hasLeftValueSatisfying_Test {
         Either<Integer, String> actual = Either.left(42);
 
         assertThatThrownBy(
-                () -> assertThat(actual).hasLeftValueSatisfying(it -> Assertions.assertThat(it).isEqualTo(24))
+                () -> assertThat(actual).hasLeftValueSatisfying(it -> assertThat(it).isEqualTo(24))
         )
                 .isInstanceOf(AssertionError.class)
                 .hasMessage(format("%nExpecting:%n <42>%nto be equal to:%n <24>%nbut was not."));
@@ -61,6 +61,6 @@ class EitherAssert_hasLeftValueSatisfying_Test {
     void should_pass_if_consumer_passes() {
         Either<Integer, String> actual = Either.left(42);
 
-        assertThat(actual).hasLeftValueSatisfying(it -> Assertions.assertThat(it).isEqualTo(42));
+        assertThat(actual).hasLeftValueSatisfying(it -> assertThat(it).isEqualTo(42));
     }
 }

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.vavr.api;
+
+import io.vavr.control.Either;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.vavr.api.EitherShouldBeLeft.shouldBeLeft;
+import static org.assertj.vavr.api.VavrAssertions.assertThat;
+
+class EitherAssert_hasLeftValueSatisfying_Test {
+
+    @Test
+    void should_fail_when_either_is_null() {
+        Either<Integer, String> actual = null;
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasLeftValueSatisfying(it -> {})
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(actualIsNull());
+    }
+
+    @Test
+    void should_fail_if_either_is_right() {
+        Either<Integer, String> actual = Either.right("something");
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasLeftValueSatisfying(it -> {})
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(shouldBeLeft(actual).create());
+    }
+
+    @Test
+    void should_fail_if_consumer_fails() {
+        Either<Integer, String> actual = Either.left(42);
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasLeftValueSatisfying(it -> Assertions.assertThat(it).isEqualTo(24))
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(format("%nExpecting:%n <42>%nto be equal to:%n <24>%nbut was not."));
+    }
+
+    @Test
+    void should_pass_if_consumer_passes() {
+        Either<Integer, String> actual = Either.left(42);
+
+        assertThat(actual).hasLeftValueSatisfying(it -> Assertions.assertThat(it).isEqualTo(42));
+    }
+}

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
@@ -22,14 +22,14 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.vavr.api.EitherShouldBeRight.shouldBeRight;
 import static org.assertj.vavr.api.VavrAssertions.assertThat;
 
-class EitherAssert_hasValueSatisfying_Test {
+class EitherAssert_hasRightValueSatisfying_Test {
 
     @Test
     void should_fail_when_either_is_null() {
         Either<Integer, String> actual = null;
 
         assertThatThrownBy(
-                () -> assertThat(actual).hasValueSatisfying(it -> {})
+                () -> assertThat(actual).hasRightValueSatisfying(it -> {})
         )
                 .isInstanceOf(AssertionError.class)
                 .hasMessage(actualIsNull());
@@ -40,7 +40,7 @@ class EitherAssert_hasValueSatisfying_Test {
         Either<Integer, String> actual = Either.left(42);
 
         assertThatThrownBy(
-                () -> assertThat(actual).hasValueSatisfying(it -> {})
+                () -> assertThat(actual).hasRightValueSatisfying(it -> {})
         )
                 .isInstanceOf(AssertionError.class)
                 .hasMessage(shouldBeRight(actual).create());
@@ -51,7 +51,7 @@ class EitherAssert_hasValueSatisfying_Test {
         Either<Integer, String> actual = Either.right("something");
 
         assertThatThrownBy(
-                () -> assertThat(actual).hasValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something else"))
+                () -> assertThat(actual).hasRightValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something else"))
         )
                 .isInstanceOf(AssertionError.class)
                 .hasMessage(format("%nExpecting:%n <\"something\">%nto be equal to:%n <\"something else\">%nbut was not."));
@@ -61,6 +61,6 @@ class EitherAssert_hasValueSatisfying_Test {
     void should_pass_if_consumer_passes() {
         Either<Integer, String> actual = Either.right("something");
 
-        assertThat(actual).hasValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something"));
+        assertThat(actual).hasRightValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something"));
     }
 }

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
@@ -13,10 +13,10 @@
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.vavr.api.EitherShouldBeRight.shouldBeRight;
@@ -51,7 +51,7 @@ class EitherAssert_hasRightValueSatisfying_Test {
         Either<Integer, String> actual = Either.right("something");
 
         assertThatThrownBy(
-                () -> assertThat(actual).hasRightValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something else"))
+                () -> assertThat(actual).hasRightValueSatisfying(it -> assertThat(it).isEqualTo("something else"))
         )
                 .isInstanceOf(AssertionError.class)
                 .hasMessage(format("%nExpecting:%n <\"something\">%nto be equal to:%n <\"something else\">%nbut was not."));
@@ -61,6 +61,6 @@ class EitherAssert_hasRightValueSatisfying_Test {
     void should_pass_if_consumer_passes() {
         Either<Integer, String> actual = Either.right("something");
 
-        assertThat(actual).hasRightValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something"));
+        assertThat(actual).hasRightValueSatisfying(it -> assertThat(it).isEqualTo("something"));
     }
 }

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasValueSatisfying_Test.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.vavr.api;
+
+import io.vavr.control.Either;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.vavr.api.EitherShouldBeRight.shouldBeRight;
+import static org.assertj.vavr.api.VavrAssertions.assertThat;
+
+class EitherAssert_hasValueSatisfying_Test {
+
+    @Test
+    void should_fail_when_either_is_null() {
+        Either<Integer, String> actual = null;
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasValueSatisfying(it -> {})
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(actualIsNull());
+    }
+
+    @Test
+    void should_fail_if_either_is_left() {
+        Either<Integer, String> actual = Either.left(42);
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasValueSatisfying(it -> {})
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(shouldBeRight(actual).create());
+    }
+
+    @Test
+    void should_fail_if_consumer_fails() {
+        Either<Integer, String> actual = Either.right("something");
+
+        assertThatThrownBy(
+                () -> assertThat(actual).hasValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something else"))
+        )
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(format("%nExpecting:%n <\"something\">%nto be equal to:%n <\"something else\">%nbut was not."));
+    }
+
+    @Test
+    void should_pass_if_consumer_passes() {
+        Either<Integer, String> actual = Either.right("something");
+
+        assertThat(actual).hasValueSatisfying(it -> Assertions.assertThat(it).isEqualTo("something"));
+    }
+}


### PR DESCRIPTION
Adds the following methods to `AbstractEitherAssert`:
* hasValueSatisfying(Consumer<RIGHT> requirement)
* hasLeftValueSatisfying(Consumer<LEFT> requirement)

These methods improve a testers ability to make further
assertions on the containing values. Copied the concept
from [AbstractOptionalAssert](http://joel-costigliola.github.io/assertj/core-8/api/org/assertj/core/api/AbstractOptionalAssert.html#hasValueSatisfying-java.util.function.Consumer-).

This should resolve #69.