### PR TITLE
Updating plugins so build works with jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,13 +193,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.2</version>
             </plugin>
 
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
I'm using jdk11 locally and I ran into an issue similar to [this](https://stackoverflow.com/questions/55272870/surefire-maven-plugin-corrupted-stdout-by-directly-writing-to-native-stream-in). The suggested fix is to upgrade the plugins. This doesn't change the target jvm of 8.