### PR TITLE
add parent POM: assertj-parent-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-parent-pom</artifactId>
+        <version>2.2.8</version>
+    </parent>
+
     <groupId>org.assertj</groupId>
     <artifactId>assertj-vavr</artifactId>
     <version>0.2.0</version>
@@ -11,7 +17,7 @@
     <name>AssertJ fluent assertions for Vavr</name>
     <description>Rich and fluent assertions for testing Vavr tools</description>
     <inceptionYear>2017</inceptionYear>
-  
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -129,17 +135,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -149,57 +154,15 @@
                     </execution>
                 </executions>
             </plugin>
-          
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
             </plugin>
 
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractEitherAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractLazyAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractLazyAssert.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractMapAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractMultimapAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractMultimapAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.Tuple;

--- a/src/main/java/org/assertj/vavr/api/AbstractOptionAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractOptionAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractSeqAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractSeqAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractSetAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractSetAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.Set;

--- a/src/main/java/org/assertj/vavr/api/AbstractTraversableAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractTraversableAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.Traversable;

--- a/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractTryAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractValidationAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractValidationAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/AbstractValueAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractValueAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.assertj.core.api.AbstractObjectAssert;

--- a/src/main/java/org/assertj/vavr/api/AbstractVavrAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractVavrAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/main/java/org/assertj/vavr/api/ClassLoadingStrategyFactory.java
+++ b/src/main/java/org/assertj/vavr/api/ClassLoadingStrategyFactory.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/main/java/org/assertj/vavr/api/EitherAssert.java
+++ b/src/main/java/org/assertj/vavr/api/EitherAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;

--- a/src/main/java/org/assertj/vavr/api/EitherShouldBeLeft.java
+++ b/src/main/java/org/assertj/vavr/api/EitherShouldBeLeft.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;

--- a/src/main/java/org/assertj/vavr/api/EitherShouldBeRight.java
+++ b/src/main/java/org/assertj/vavr/api/EitherShouldBeRight.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;

--- a/src/main/java/org/assertj/vavr/api/EitherShouldContain.java
+++ b/src/main/java/org/assertj/vavr/api/EitherShouldContain.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/EitherShouldContainInstanceOf.java
+++ b/src/main/java/org/assertj/vavr/api/EitherShouldContainInstanceOf.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/LazyAssert.java
+++ b/src/main/java/org/assertj/vavr/api/LazyAssert.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/LazyShouldBeEvaluated.java
+++ b/src/main/java/org/assertj/vavr/api/LazyShouldBeEvaluated.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/LazyShouldBeNotEvaluated.java
+++ b/src/main/java/org/assertj/vavr/api/LazyShouldBeNotEvaluated.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/MapAssert.java
+++ b/src/main/java/org/assertj/vavr/api/MapAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.Map;

--- a/src/main/java/org/assertj/vavr/api/MultimapAssert.java
+++ b/src/main/java/org/assertj/vavr/api/MultimapAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.Multimap;

--- a/src/main/java/org/assertj/vavr/api/OptionAssert.java
+++ b/src/main/java/org/assertj/vavr/api/OptionAssert.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/OptionShouldBeEmpty.java
+++ b/src/main/java/org/assertj/vavr/api/OptionShouldBeEmpty.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Option;

--- a/src/main/java/org/assertj/vavr/api/OptionShouldBePresent.java
+++ b/src/main/java/org/assertj/vavr/api/OptionShouldBePresent.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/OptionShouldContain.java
+++ b/src/main/java/org/assertj/vavr/api/OptionShouldContain.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/OptionShouldContainInstanceOf.java
+++ b/src/main/java/org/assertj/vavr/api/OptionShouldContainInstanceOf.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/SeqAssert.java
+++ b/src/main/java/org/assertj/vavr/api/SeqAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.assertj.core.api.AssertFactory;

--- a/src/main/java/org/assertj/vavr/api/SeqShouldBeAtIndex.java
+++ b/src/main/java/org/assertj/vavr/api/SeqShouldBeAtIndex.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/SeqShouldBeSorted.java
+++ b/src/main/java/org/assertj/vavr/api/SeqShouldBeSorted.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/SeqShouldHaveAtIndex.java
+++ b/src/main/java/org/assertj/vavr/api/SeqShouldHaveAtIndex.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.assertj.core.api.Condition;

--- a/src/main/java/org/assertj/vavr/api/SetAssert.java
+++ b/src/main/java/org/assertj/vavr/api/SetAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.HashSet;

--- a/src/main/java/org/assertj/vavr/api/ShouldNotContainValues.java
+++ b/src/main/java/org/assertj/vavr/api/ShouldNotContainValues.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.assertj.core.error.BasicErrorMessageFactory;

--- a/src/main/java/org/assertj/vavr/api/TryAssert.java
+++ b/src/main/java/org/assertj/vavr/api/TryAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/main/java/org/assertj/vavr/api/TryShouldBeFailure.java
+++ b/src/main/java/org/assertj/vavr/api/TryShouldBeFailure.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/TryShouldBeSuccess.java
+++ b/src/main/java/org/assertj/vavr/api/TryShouldBeSuccess.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/TryShouldContain.java
+++ b/src/main/java/org/assertj/vavr/api/TryShouldContain.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/TryShouldContainInstanceOf.java
+++ b/src/main/java/org/assertj/vavr/api/TryShouldContainInstanceOf.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/ValidationAssert.java
+++ b/src/main/java/org/assertj/vavr/api/ValidationAssert.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Validation;

--- a/src/main/java/org/assertj/vavr/api/ValidationShouldBeInvalid.java
+++ b/src/main/java/org/assertj/vavr/api/ValidationShouldBeInvalid.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Validation;

--- a/src/main/java/org/assertj/vavr/api/ValidationShouldBeValid.java
+++ b/src/main/java/org/assertj/vavr/api/ValidationShouldBeValid.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Validation;

--- a/src/main/java/org/assertj/vavr/api/ValidationShouldContain.java
+++ b/src/main/java/org/assertj/vavr/api/ValidationShouldContain.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/ValidationShouldContainInstanceOf.java
+++ b/src/main/java/org/assertj/vavr/api/ValidationShouldContainInstanceOf.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/main/java/org/assertj/vavr/api/VavrAssertions.java
+++ b/src/main/java/org/assertj/vavr/api/VavrAssertions.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/VavrAssumptions.java
+++ b/src/main/java/org/assertj/vavr/api/VavrAssumptions.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.Lazy;

--- a/src/main/java/org/assertj/vavr/internal/Maps.java
+++ b/src/main/java/org/assertj/vavr/internal/Maps.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.internal;
 
 import io.vavr.Tuple;

--- a/src/main/java/org/assertj/vavr/internal/Multimaps.java
+++ b/src/main/java/org/assertj/vavr/internal/Multimaps.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.internal;
 
 import io.vavr.Tuple;

--- a/src/test/java/org/assertj/vavr/api/AssumptionRunner.java
+++ b/src/test/java/org/assertj/vavr/api/AssumptionRunner.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 abstract class AssumptionRunner<T> {

--- a/src/test/java/org/assertj/vavr/api/BaseAssumptionRunner.java
+++ b/src/test/java/org/assertj/vavr/api/BaseAssumptionRunner.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import java.util.function.Consumer;

--- a/src/test/java/org/assertj/vavr/api/BaseAssumptionsTest.java
+++ b/src/test/java/org/assertj/vavr/api/BaseAssumptionsTest.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import org.junit.AssumptionViolatedException;

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeftInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeftInstanceOf_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeftSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeftSame_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeft_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsLeft_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnLeft_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnLeft_usingFieldByFieldValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnLeft_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnLeft_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnRight_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnRight_usingFieldByFieldValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnRight_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsOnRight_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsRightInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsRightInstanceOf_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsRightSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsRightSame_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_containsRight_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_containsRight_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasLeftValueSatisfying_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_hasRightValueSatisfying_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_isLeft_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_isLeft_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/EitherAssert_isRight_Test.java
+++ b/src/test/java/org/assertj/vavr/api/EitherAssert_isRight_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/Either_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Either_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Either;

--- a/src/test/java/org/assertj/vavr/api/LazyAssert_isEvaluated_Test.java
+++ b/src/test/java/org/assertj/vavr/api/LazyAssert_isEvaluated_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/LazyAssert_isNotEvaluated_Test.java
+++ b/src/test/java/org/assertj/vavr/api/LazyAssert_isNotEvaluated_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/Lazy_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Lazy_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.Lazy;

--- a/src/test/java/org/assertj/vavr/api/MapAssert_allSatisfy_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_allSatisfy_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsAllEntriesOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsAllEntriesOf_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsEntry_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsEntry_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsExactly_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsKey_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsKey_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsOnlyKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsOnly_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsOnly_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsValue_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsValue_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_containsValues_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_containsValues_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_contains_anyOf_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_contains_anyOf_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_contains_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_contains_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainEntry_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainEntry_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainKey_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainKey_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainValue_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainValue_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainValues_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContainValues_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContain_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_doesNotContain_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasEntrySatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasEntrySatisfying_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasSameSizeAs_Array_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasSameSizeAs_Array_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasSameSizeAs_Iterable_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasSameSizeAs_Iterable_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasSizeGreaterThan_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasSizeLessThan_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_hasSize_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_isEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_isEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_isEqualTo_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_isNotEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_isNotEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_isNotEqualTo_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MapAssert_isNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MapAssert_isNullOrEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/Map_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Map_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.Tuple;

--- a/src/test/java/org/assertj/vavr/api/MultiMapAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultiMapAssert_isEqualTo_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultiMapAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultiMapAssert_isNotEqualTo_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_allSatisfy_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_allSatisfy_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsAllEntriesOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsAllEntriesOf_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsEntry_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsEntry_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsExactly_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsKey_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsKey_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsOnlyKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsOnly_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsOnly_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsValue_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsValue_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_containsValues_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_containsValues_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_contains_anyOf_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_contains_anyOf_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_contains_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_contains_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainEntry_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainEntry_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainKey_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainKey_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainKeys_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainKeys_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainValue_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainValue_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainValues_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContainValues_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContain_entries_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_doesNotContain_entries_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasEntrySatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasEntrySatisfying_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSameSizeAs_Array_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSameSizeAs_Array_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSameSizeAs_Iterable_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSameSizeAs_Iterable_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSizeGreaterThan_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSizeLessThan_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_hasSize_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_isEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_isEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_isNotEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_isNotEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/MultimapAssert_isNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/MultimapAssert_isNullOrEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/Multimap_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Multimap_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.Tuple;

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_containsInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_containsInstanceOf_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_containsSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_containsSame_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_contains_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_contains_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_contains_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_contains_usingFieldByFieldValueComparator_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_contains_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_contains_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_flatMap_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_flatMap_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_hasValueSatisfying_Condition_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_hasValueSatisfying_Condition_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_hasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_hasValueSatisfying_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_isDefined_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_isDefined_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_isEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_isEmpty_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/OptionAssert_map_Test.java
+++ b/src/test/java/org/assertj/vavr/api/OptionAssert_map_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/Option_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Option_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Option;

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_contains_atIndex_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_contains_atIndex_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_doesNotContain_atIndex_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_doesNotContain_atIndex_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_has_atIndex_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_has_atIndex_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_isSortedAccordingTo_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_isSortedAccordingTo_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_isSorted_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_isSorted_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_satisfies_atIndex_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_satisfies_atIndex_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/Seq_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Seq_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.List;

--- a/src/test/java/org/assertj/vavr/api/SetAssert_allSatisfy_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SetAssert_allSatisfy_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.HashSet;

--- a/src/test/java/org/assertj/vavr/api/SetAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SetAssert_hasSize_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.HashSet;

--- a/src/test/java/org/assertj/vavr/api/SetAssert_isEmpty_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SetAssert_isEmpty_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 /*

--- a/src/test/java/org/assertj/vavr/api/Set_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Set_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.collection.Array;

--- a/src/test/java/org/assertj/vavr/api/TestCondition.java
+++ b/src/test/java/org/assertj/vavr/api/TestCondition.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2017 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/TryAssert_containsInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_containsInstanceOf_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_containsSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_containsSame_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_contains_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_contains_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_contains_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_contains_usingFieldByFieldValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/TryAssert_contains_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_contains_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/TryAssert_failBecauseOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_failBecauseOf_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_failReasonHasMessage_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_failReasonHasMessage_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_hasValueSatisfying_Condition_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_hasValueSatisfying_Condition_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_hasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_hasValueSatisfying_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_isFailure_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_isFailure_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/TryAssert_isSuccess_Test.java
+++ b/src/test/java/org/assertj/vavr/api/TryAssert_isSuccess_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/Try_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Try_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Try;

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalidInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalidInstanceOf_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalidSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalidSame_Test.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_Test.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_usingFieldByFieldValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsInvalid_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValidInstanceOf_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValidInstanceOf_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValidSame_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValidSame_Test.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_Test.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_usingFieldByFieldValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_usingFieldByFieldValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_usingValueComparator_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_containsValid_usingValueComparator_Test.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_isInvalid_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_isInvalid_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/ValidationAssert_isValid_Test.java
+++ b/src/test/java/org/assertj/vavr/api/ValidationAssert_isValid_Test.java
@@ -1,14 +1,14 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * <p>
- * Copyright 2012-2019 the original author or authors.
+ *
+ * Copyright 2017-2020 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/Validation_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/vavr/api/Validation_assertion_methods_in_assumptions_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2020 the original author or authors.
+ */
 package org.assertj.vavr.api;
 
 import io.vavr.control.Validation;


### PR DESCRIPTION
The parent POM activates the [license-maven-plugin]

This plugin adds a license header to Java source files.