### PR TITLE
Fix: use custom element comparator when provided for SeqAssertions

### DIFF
--- a/src/main/java/org/assertj/vavr/api/AbstractSeqAssert.java
+++ b/src/main/java/org/assertj/vavr/api/AbstractSeqAssert.java
@@ -19,6 +19,7 @@ import org.assertj.core.api.IndexedObjectEnumerableAssert;
 import org.assertj.core.data.Index;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.Iterables;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.util.CheckReturnValue;
 
@@ -67,6 +68,7 @@ abstract class AbstractSeqAssert<SELF extends AbstractSeqAssert<SELF, ACTUAL, EL
      */
     @CheckReturnValue
     public SELF usingElementComparator(Comparator<? super ELEMENT> customComparator) {
+        this.iterables = new Iterables(new ComparatorBasedComparisonStrategy(customComparator));
         seqElementComparisonStrategy = new ComparatorBasedComparisonStrategy(customComparator);
         return myself;
     }

--- a/src/test/java/org/assertj/vavr/api/SeqAssert_containsExactly_inAnyOrder_Test.java
+++ b/src/test/java/org/assertj/vavr/api/SeqAssert_containsExactly_inAnyOrder_Test.java
@@ -33,6 +33,15 @@ class SeqAssert_containsExactly_inAnyOrder_Test {
     }
 
     @Test
+    void should_pass_if_List_contains_exactly_elements_in_any_order_using_element_comparator() {
+        final Set<String> expectedInAnyOrder = HashSet.of("other", "and", "else", "something");
+        final List<String> uppercaseList = expectedInAnyOrder.map(String::toUpperCase).toList().reverse();
+        assertThat(uppercaseList)
+                .usingElementComparator(String::compareToIgnoreCase)
+                .containsExactlyInAnyOrder(expectedInAnyOrder);
+    }
+
+    @Test
     void should_fail_when_List_is_null() {
         final Set<String> expectedInAnyOrder = HashSet.of("other", "and", "else", "something");
         assertThatThrownBy(

--- a/src/test/java/org/assertj/vavr/api/soft/JUnitSoftVavrAssertionsFailureTest.java
+++ b/src/test/java/org/assertj/vavr/api/soft/JUnitSoftVavrAssertionsFailureTest.java
@@ -44,7 +44,7 @@ public class JUnitSoftVavrAssertionsFailureTest {
         // THEN
         List<Throwable> failures = multipleFailuresError.getFailures();
         assertThat(failures).hasSize(2);
-        assertThat(failures.get(0)).hasMessageStartingWith(format("[contains] %nExpecting:%n  <Left(something)>%nto contain:%n  <\"else\">%nbut did not."));
+        assertThat(failures.get(0)).hasMessageStartingWith(format("[contains] %nExpecting:%n  <Left(something)>%nto contain:%n  <\"else\"> on the [LEFT]%nbut did not."));
         assertThat(failures.get(1)).hasMessageStartingWith(format("[instance] %nExpecting:%n" +
                 " <Left>%n" +
                 "to contain a value that is an instance of:%n" +


### PR DESCRIPTION
fixes Seq assertions like `containsExactlyInAnyOrder` and makes assertj-vavr in line with assertj-core.