### PR TITLE
Added VavrInstanceOfAssertFactories helper class

### DIFF
--- a/src/main/java/org/assertj/vavr/api/VavrAssertions.java
+++ b/src/main/java/org/assertj/vavr/api/VavrAssertions.java
@@ -27,7 +27,7 @@ import org.assertj.core.util.CheckReturnValue;
  * @author Grzegorz Piwowarek
  */
 @CheckReturnValue
-public final class VavrAssertions {
+public final class VavrAssertions implements VavrInstanceOfAssertFactories {
 
     private VavrAssertions() {
     }

--- a/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
@@ -28,7 +28,7 @@ import org.assertj.core.api.InstanceOfAssertFactory;
  * Static {@link VavrInstanceOfAssertFactories VavrInstanceOfAssertFactories} for {@link Assert#asInstanceOf(InstanceOfAssertFactory)}.
  *
  * @author Eduard Dudar
- * @since 0.4.4
+ * @since 0.5.0
  */
 @SuppressWarnings({
         "rawtypes", // using Class instance

--- a/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
@@ -21,8 +21,15 @@ import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
+import org.assertj.core.api.Assert;
 import org.assertj.core.api.InstanceOfAssertFactory;
 
+/**
+ * Static {@link VavrInstanceOfAssertFactories VavrInstanceOfAssertFactories} for {@link Assert#asInstanceOf(InstanceOfAssertFactory)}.
+ *
+ * @author Eduard Dudar
+ * @since 0.4.4
+ */
 @SuppressWarnings({
         "rawtypes", // using Class instance
         "unused", // parameter needed for type inference.

--- a/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2017-2024 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/vavr/api/VavrInstanceOfAssertFactories.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2023 the original author or authors.
+ */
+package org.assertj.vavr.api;
+
+import io.vavr.Lazy;
+import io.vavr.collection.Map;
+import io.vavr.collection.Multimap;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Set;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import io.vavr.control.Validation;
+import org.assertj.core.api.InstanceOfAssertFactory;
+
+@SuppressWarnings({
+        "rawtypes", // using Class instance
+        "unused", // parameter needed for type inference.
+})
+public interface VavrInstanceOfAssertFactories {
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Either}, assuming {@code Object} as left and right types.
+     *
+     * @see #either(Class, Class)
+     */
+    InstanceOfAssertFactory<Either, EitherAssert<Object, Object>> EITHER = either(Object.class, Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Either}.
+     *
+     * @param <L>   the {@link Either} left type.
+     * @param <R>   the {@link Either} right type.
+     * @param ltype the left type instance.
+     * @param rtype the right type instance.
+     * @return the factory instance.
+     * @see #EITHER
+     */
+    static <L, R> InstanceOfAssertFactory<Either, EitherAssert<L, R>> either(Class<L> ltype, Class<R> rtype) {
+        return new InstanceOfAssertFactory<>(Either.class, VavrAssertions::<L, R>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Lazy}, assuming {@code Object} as input type.
+     *
+     * @see #lazy(Class)
+     */
+    InstanceOfAssertFactory<Lazy, LazyAssert<Object>> LAZY = lazy(Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Lazy}.
+     *
+     * @param <T>  the {@code Lazy} type.
+     * @param type the type instance.
+     * @return the factory instance.
+     * @see #LAZY
+     */
+    static <T> InstanceOfAssertFactory<Lazy, LazyAssert<T>> lazy(Class<T> type) {
+        return new InstanceOfAssertFactory<>(Lazy.class, VavrAssertions::<T>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Map}, assuming {@code Object} as key and value types.
+     *
+     * @see #map(Class, Class)
+     */
+    InstanceOfAssertFactory<Map, MapAssert<Object, Object>> MAP = map(Object.class, Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Map}.
+     *
+     * @param <K>   the {@link Map} key type.
+     * @param <V>   the {@link Map} value type.
+     * @param ktype the key type instance.
+     * @param vtype the value type instance.
+     * @return the factory instance.
+     * @see #MAP
+     */
+    static <K, V> InstanceOfAssertFactory<Map, MapAssert<K, V>> map(Class<K> ktype, Class<V> vtype) {
+        return new InstanceOfAssertFactory<>(Map.class, VavrAssertions::<K, V>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Multimap}, assuming {@code Object} as input type.
+     *
+     * @see #multimap(Class, Class)
+     */
+    InstanceOfAssertFactory<Multimap, MultimapAssert<Object, Object>> MULTIMAP = multimap(Object.class, Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Multimap}.
+     *
+     * @param <K>   the {@code Multimap} key type.
+     * @param <V>   the {@code Multimap} value type.
+     * @param ktype the key type instance.
+     * @param vtype the value type instance.
+     * @return the factory instance.
+     * @see #MULTIMAP
+     */
+    static <K, V> InstanceOfAssertFactory<Multimap, MultimapAssert<K, V>> multimap(Class<K> ktype, Class<V> vtype) {
+        return new InstanceOfAssertFactory<>(Multimap.class, VavrAssertions::<K, V>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Option}, assuming {@code Object} as input type.
+     *
+     * @see #option(Class)
+     */
+    InstanceOfAssertFactory<Option, OptionAssert<Object>> OPTION = option(Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Option}.
+     *
+     * @param <T>  the {@link Option} type.
+     * @param type the type instance.
+     * @return the factory instance.
+     * @see #OPTION
+     */
+    static <T> InstanceOfAssertFactory<Option, OptionAssert<T>> option(Class<T> type) {
+        return new InstanceOfAssertFactory<>(Option.class, VavrAssertions::<T>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Seq}, assuming {@code Object} as input type.
+     *
+     * @see #seq(Class)
+     */
+    InstanceOfAssertFactory<Seq, SeqAssert<Object>> SEQ = seq(Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Seq}.
+     *
+     * @param <T>  the {@link Seq} type.
+     * @param type the type instance.
+     * @return the factory instance.
+     * @see #SEQ
+     */
+    static <T> InstanceOfAssertFactory<Seq, SeqAssert<T>> seq(Class<T> type) {
+        return new InstanceOfAssertFactory<>(Seq.class, VavrAssertions::<T>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Set}, assuming {@code Object} as input type.
+     *
+     * @see #set(Class)
+     */
+    InstanceOfAssertFactory<Set, SetAssert<Object>> SET = set(Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Set}.
+     *
+     * @param <T>  the {@link Set} type.
+     * @param type the type instance.
+     * @return the factory instance.
+     * @see #SET
+     */
+    static <T> InstanceOfAssertFactory<Set, SetAssert<T>> set(Class<T> type) {
+        return new InstanceOfAssertFactory<>(Set.class, VavrAssertions::<T>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Try}, assuming {@code Object} as input type.
+     *
+     * @see #_try(Class)
+     */
+    InstanceOfAssertFactory<Try, TryAssert<Object>> TRY = _try(Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Try}.
+     *
+     * @param <T>  the {@link Try} type.
+     * @param type the type instance.
+     * @return the factory instance.
+     * @see #TRY
+     */
+    static <T> InstanceOfAssertFactory<Try, TryAssert<T>> _try(Class<T> type) {
+        return new InstanceOfAssertFactory<>(Try.class, VavrAssertions::<T>assertThat);
+    }
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Validation}, assuming {@code Object} as invalid and valid types.
+     *
+     * @see #validation(Class, Class)
+     */
+    InstanceOfAssertFactory<Validation, ValidationAssert<Object, Object>> VALIDATION =
+            validation(Object.class, Object.class);
+
+    /**
+     * {@link InstanceOfAssertFactory} for a {@link Validation}.
+     *
+     * @param <I>   the {@link Validation} invalid type.
+     * @param <V>   the {@link Validation} valid type.
+     * @param itype the invalid type instance.
+     * @param vtype the valid type instance.
+     * @return the factory instance.
+     * @see #VALIDATION
+     */
+    static <I, V> InstanceOfAssertFactory<Validation, ValidationAssert<I, V>> validation(Class<I> itype, Class<V> vtype) {
+        return new InstanceOfAssertFactory<>(Validation.class, VavrAssertions::<I, V>assertThat);
+    }
+}

--- a/src/test/java/org/assertj/vavr/api/VavrInstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/vavr/api/VavrInstanceOfAssertFactoriesTest.java
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2017-2024 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  */
 package org.assertj.vavr.api;
 

--- a/src/test/java/org/assertj/vavr/api/VavrInstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/vavr/api/VavrInstanceOfAssertFactoriesTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2017-2024 the original author or authors.
+ */
+package org.assertj.vavr.api;
+
+import io.vavr.Lazy;
+import io.vavr.collection.Array;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.HashMultimap;
+import io.vavr.collection.HashSet;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import io.vavr.control.Validation;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.vavr.api.VavrInstanceOfAssertFactories.*;
+
+/**
+ * @author Eduard Dudar
+ */
+class VavrInstanceOfAssertFactoriesTest {
+
+    @Test
+    void either_factory_should_allow_either_assertions() {
+        // GIVEN
+        Object value = Either.left("left");
+        // WHEN
+        EitherAssert<Object, Object> result = assertThat(value).asInstanceOf(EITHER);
+        // THEN
+        result.isLeft();
+    }
+
+    @Test
+    void either_typed_factory_should_allow_either_typed_assertions() {
+        // GIVEN
+        Object value = Either.right("right");
+        // WHEN
+        EitherAssert<String, String> result = assertThat(value).asInstanceOf(either(String.class, String.class));
+        // THEN
+        result.isRight();
+    }
+
+    @Test
+    void lazy_factory_should_allow_lazy_assertions() {
+        // GIVEN
+        Object value = Lazy.of(() -> "lazy");
+        // WHEN
+        LazyAssert<Object> result = assertThat(value).asInstanceOf(LAZY);
+        // THEN
+        result.isNotEvaluated();
+    }
+
+    @Test
+    void lazy_typed_factory_should_allow_lazy_typed_assertions() {
+        // GIVEN
+        Object value = Lazy.of(() -> "lazy");
+        // WHEN
+        LazyAssert<String> result = assertThat(value).asInstanceOf(lazy(String.class));
+        // THEN
+        result.isNotEvaluated();
+    }
+
+    @Test
+    void map_factory_should_allow_map_assertions() {
+        // GIVEN
+        Object value = HashMap.of("key1", "value1");
+        // WHEN
+        MapAssert<Object, Object> result = assertThat(value).asInstanceOf(MAP);
+        // THEN
+        result.containsKey("key1");
+    }
+
+    @Test
+    void map_typed_factory_should_allow_map_typed_assertions() {
+        // GIVEN
+        Object value = HashMap.of("key1", "value1");
+        // WHEN
+        MapAssert<String, String> result = assertThat(value).asInstanceOf(map(String.class, String.class));
+        // THEN
+        result.containsKey("key1");
+    }
+
+    @Test
+    void multimap_factory_should_allow_multimap_assertions() {
+        // GIVEN
+        Object value = HashMultimap.withSet().of("key1", "value1");
+        // WHEN
+        MultimapAssert<Object, Object> result = assertThat(value).asInstanceOf(MULTIMAP);
+        // THEN
+        result.containsKey("key1");
+    }
+
+    @Test
+    void multimap_typed_factory_should_allow_multimap_typed_assertions() {
+        // GIVEN
+        Object value = HashMultimap.withSet().of("key1", "value1");
+        // WHEN
+        MultimapAssert<String, String> result = assertThat(value).asInstanceOf(multimap(String.class, String.class));
+        // THEN
+        result.containsKey("key1");
+    }
+
+    @Test
+    void option_factory_should_allow_option_assertions() {
+        // GIVEN
+        Object value = Option.of("maybe");
+        // WHEN
+        OptionAssert<Object> result = assertThat(value).asInstanceOf(OPTION);
+        // THEN
+        result.isDefined();
+    }
+
+    @Test
+    void option_typed_factory_should_allow_option_typed_assertions() {
+        // GIVEN
+        Object value = Option.of("maybe");
+        // WHEN
+        OptionAssert<String> result = assertThat(value).asInstanceOf(option(String.class));
+        // THEN
+        result.isDefined();
+    }
+
+    @Test
+    void seq_factory_should_allow_seq_assertions() {
+        // GIVEN
+        Object value = Array.of("value1");
+        // WHEN
+        SeqAssert<Object> result = assertThat(value).asInstanceOf(SEQ);
+        // THEN
+        result.hasSize(1);
+    }
+
+    @Test
+    void seq_typed_factory_should_allow_seq_typed_assertions() {
+        // GIVEN
+        Object value = Array.of("value1", "value2");
+        // WHEN
+        SeqAssert<String> result = assertThat(value).asInstanceOf(seq(String.class));
+        // THEN
+        result.hasSize(2);
+    }
+
+    @Test
+    void set_factory_should_allow_set_assertions() {
+        // GIVEN
+        Object value = HashSet.of("value1");
+        // WHEN
+        SetAssert<Object> result = assertThat(value).asInstanceOf(SET);
+        // THEN
+        result.hasSize(1);
+    }
+
+    @Test
+    void set_typed_factory_should_allow_set_typed_assertions() {
+        // GIVEN
+        Object value = HashSet.of("value1", "value2");
+        // WHEN
+        SetAssert<String> result = assertThat(value).asInstanceOf(set(String.class));
+        // THEN
+        result.hasSize(2);
+    }
+
+    @Test
+    void try_factory_should_allow_try_assertions() {
+        // GIVEN
+        Object value = Try.of(() -> "should we");
+        // WHEN
+        TryAssert<Object> result = assertThat(value).asInstanceOf(TRY);
+        // THEN
+        result.isSuccess();
+    }
+
+    @Test
+    void try_typed_factory_should_allow_try_typed_assertions() {
+        // GIVEN
+        Object value = Try.of(() -> "should we");
+        // WHEN
+        TryAssert<String> result = assertThat(value).asInstanceOf(_try(String.class));
+        // THEN
+        result.isSuccess();
+    }
+
+    @Test
+    void validation_factory_should_allow_validation_assertions() {
+        // GIVEN
+        Object value = Validation.valid("value");
+        // WHEN
+        ValidationAssert<Object, Object> result = assertThat(value).asInstanceOf(VALIDATION);
+        // THEN
+        result.isValid();
+    }
+
+    @Test
+    void validation_typed_factory_should_allow_validation_typed_assertions() {
+        // GIVEN
+        Object value = Validation.invalid("error");
+        // WHEN
+        ValidationAssert<Integer, String> result =
+                assertThat(value).asInstanceOf(validation(Integer.class, String.class));
+        // THEN
+        result.isInvalid();
+    }
+
+}


### PR DESCRIPTION
Added `VavrInstanceOfAssertFactories` helper class, which is structurally identical to the original `InstanceOfAssertFactories`. `VavrAssertions` now "implement" it, same as original `Assertions`.

Closes #134 